### PR TITLE
use create if not exists rather than checking separately

### DIFF
--- a/scripts/migrationSettings.json
+++ b/scripts/migrationSettings.json
@@ -1,7 +1,7 @@
 {
   "getKeyspace": "SELECT keyspace_name FROM system.schema_keyspaces WHERE keyspace_name=?;",
   "getColumnFamily": "SELECT columnfamily_name FROM system.schema_columnfamilies WHERE keyspace_name=? and columnfamily_name = 'sys_cassandra_migrations';",
-  "createMigrationTable": "CREATE TABLE sys_cassandra_migrations(file_name TEXT, created_at TIMESTAMP, migration_number TEXT, title TEXT, PRIMARY KEY (file_name, created_at));",
+  "createMigrationTable": "CREATE TABLE IF NOT EXISTS sys_cassandra_migrations(file_name TEXT, created_at TIMESTAMP, migration_number TEXT, title TEXT, PRIMARY KEY (file_name, created_at));",
   "getMigration": "SELECT * from sys_cassandra_migrations;",
   "insertMigration": "INSERT INTO sys_cassandra_migrations(file_name, created_at, migration_number, title) values(?, ?, ?, ?);",
   "deleteMigration": "DELETE FROM sys_cassandra_migrations where file_name=?;"


### PR DESCRIPTION
The migration_settings.getColumnFamily was erroring out because the table didn't exist yet. Not sure how this ever worked to be honest. But if you change the create table command to include "IF NOT EXISTS" solves the issue and simplifies the code at the same time.