### PR TITLE
migrations also accept _ now

### DIFF
--- a/bin/migrate.js
+++ b/bin/migrate.js
@@ -75,10 +75,10 @@ var createMigration = function (title) {
   var files = fs.readdirSync(process.cwd()),
     migFiles = [],
     count,
-    reTitle = /^[a-z0-9]*$/i;
+    reTitle = /^[a-z0-9\_]*$/i;
 
   if (!reTitle.test(title)) {
-    console.log('Invalid title. Only alphanumeric title is accepted.');
+    console.log("Invalid title. Only alphanumeric and '_' title is accepted.");
     process.exit(1);
   }
 


### PR DESCRIPTION
So I'm not sure what the rationale was for restricting the migration names so much but it seems like _ should also be allowed so that they can be more readable. 