### PR TITLE
Underscore migrations

### DIFF
--- a/bin/migrate.js
+++ b/bin/migrate.js
@@ -75,10 +75,10 @@ var createMigration = function (title) {
   var files = fs.readdirSync(process.cwd()),
     migFiles = [],
     count,
-    reTitle = /^[a-z0-9]*$/i;
+    reTitle = /^[a-z0-9\_]*$/i;
 
   if (!reTitle.test(title)) {
-    console.log('Invalid title. Only alphanumeric title is accepted.');
+    console.log("Invalid title. Only alphanumeric and '_' title is accepted.");
     process.exit(1);
   }
 

--- a/bin/migrate.js
+++ b/bin/migrate.js
@@ -14,7 +14,7 @@ var program = require("commander"),
   batchQueries = [],
   upQueries = [],
   downQueries = [],
-  reFileName = /^[0-9]{10}_[a-z0-9]*.js$/i, // regex to find migration files.,
+  reFileName = /^[0-9]{10}_[a-z0-9\_]*.js$/i, // regex to find migration files.,
   filesRan = [],
   path = require('path');
 


### PR DESCRIPTION
So I'm not sure what the rationale was for restricting the migration names so much but it seems like _ should also be allowed so that they can be more readable. 