### PR TITLE
Name migrations properly

### DIFF
--- a/bin/migrate.js
+++ b/bin/migrate.js
@@ -213,7 +213,7 @@ var prepareMigrations = function (callback) {
                 fileName = migFilesAvail[ migAvail.indexOf(migApplied[ k ]) ],
                 attributes = fileName.split("_"),
                 query = {
-                  'file': fileName, 'num': attributes[ 0 ], 'name': attributes[ 1 ].replace(".js", ""),
+                  'file': fileName, 'num': attributes[ 0 ], 'name': fileName.replace(".js", ""),
                   run: require(path.resolve(cwd + "/" + fileName))
                 };
 
@@ -242,7 +242,7 @@ var prepareMigrations = function (callback) {
               var fileName = migFilesAvail[ migAvail.indexOf(migAvail[ k ]) ],
                 attributes = fileName.split("_"),
                 query = {
-                  'file': fileName, 'num': attributes[ 0 ], 'name': attributes[ 1 ].replace(".js", ""),
+                  'file': fileName, 'num': attributes[ 0 ], 'name': fileName.replace(".js", ""),
                   'run': require(path.resolve(cwd + "/" + fileName))
                 };
               upQueries.push(query);

--- a/scripts/migrationSettings.json
+++ b/scripts/migrationSettings.json
@@ -1,7 +1,7 @@
 {
   "getKeyspace": "SELECT keyspace_name FROM system.schema_keyspaces WHERE keyspace_name=?;",
   "getColumnFamily": "SELECT columnfamily_name FROM system.schema_columnfamilies WHERE keyspace_name=? and columnfamily_name = 'sys_cassandra_migrations';",
-  "createMigrationTable": "CREATE TABLE sys_cassandra_migrations(file_name TEXT, created_at TIMESTAMP, migration_number TEXT, title TEXT, PRIMARY KEY (file_name, created_at));",
+  "createMigrationTable": "CREATE TABLE IF NOT EXISTS sys_cassandra_migrations(file_name TEXT, created_at TIMESTAMP, migration_number TEXT, title TEXT, PRIMARY KEY (file_name, created_at));",
   "getMigration": "SELECT * from sys_cassandra_migrations;",
   "insertMigration": "INSERT INTO sys_cassandra_migrations(file_name, created_at, migration_number, title) values(?, ?, ?, ?);",
   "deleteMigration": "DELETE FROM sys_cassandra_migrations where file_name=?;"


### PR DESCRIPTION
Migrations right are named with just the timestamp. This change makes it the entire migration file, minus the '.js'. 

